### PR TITLE
Fix warning: enumeration value 'LDNodeNone' not handled in switch [-W…

### DIFF
--- a/ldevents.c
+++ b/ldevents.c
@@ -102,6 +102,8 @@ addNodeToJSONObject(cJSON *obj, const char *key, LDNode *node)
     case LDNodeHash:
         cJSON_AddItemToObject(obj, key, LDi_hashtojson(node->h));
         break;
+    case LDNodeArray:
+        cJSON_AddItemToObject(obj, key, LDi_arraytojson(node->a));
     default:
         break;
     }

--- a/ldevents.c
+++ b/ldevents.c
@@ -102,6 +102,8 @@ addNodeToJSONObject(cJSON *obj, const char *key, LDNode *node)
     case LDNodeHash:
         cJSON_AddItemToObject(obj, key, LDi_hashtojson(node->h));
         break;
+    default:
+        break;
     }
 };
 

--- a/ldhash.c
+++ b/ldhash.c
@@ -166,6 +166,8 @@ LDi_hashtoversionedjson(LDNode *hash)
         case LDNodeArray:
             cJSON_AddItemToObject(val, "value", LDi_arraytojson(node->a));
             break;
+        case LDNodeNone:
+            break;
         }
         if (node->version)
             cJSON_AddNumberToObject(val, "version", node->version);
@@ -202,6 +204,8 @@ LDi_hashtojson(LDNode *hash)
         case LDNodeArray:
             cJSON_AddItemToObject(json, node->key, LDi_arraytojson(node->a));
             break;
+        case LDNodeNone:
+            break;
         }
     }
     return json;
@@ -228,6 +232,8 @@ LDi_arraytojson(LDNode *hash)
             break;
         case LDNodeArray:
             cJSON_AddItemToArray(json, LDi_arraytojson(node->a));
+            break;
+        case LDNodeNone:
             break;
         }
     }
@@ -422,6 +428,8 @@ LDNodeToJSON(LDNode *node)
         break;
     case LDNodeHash:
         json = LDi_hashtojson(node);
+        break;
+    default:
         break;
     }
     if (json) {


### PR DESCRIPTION
…switch]

```
gcc -fPIC -std=c99 -D_XOPEN_SOURCE=600    -c -o ldevents.o ldevents.c
ldevents.c:92:13: warning: enumeration values 'LDNodeNone' and 'LDNodeArray' not handled in switch [-Wswitch]
    switch (node->type) {
            ^
ldevents.c:92:13: note: add missing switch cases
    switch (node->type) {
            ^
1 warning generated.
gcc -fPIC -std=c99 -D_XOPEN_SOURCE=600    -c -o ldhash.o ldhash.c
ldhash.c:153:17: warning: enumeration value 'LDNodeNone' not handled in switch [-Wswitch]
        switch (node->type) {
                ^
ldhash.c:153:17: note: add missing switch cases
        switch (node->type) {
                ^
ldhash.c:189:17: warning: enumeration value 'LDNodeNone' not handled in switch [-Wswitch]
        switch (node->type) {
                ^
ldhash.c:189:17: note: add missing switch cases
        switch (node->type) {
                ^
ldhash.c:216:17: warning: enumeration value 'LDNodeNone' not handled in switch [-Wswitch]
        switch (node->type) {
                ^
ldhash.c:216:17: note: add missing switch cases
        switch (node->type) {
                ^
ldhash.c:419:13: warning: 4 enumeration values not handled in switch: 'LDNodeNone', 'LDNodeString', 'LDNodeNumber'... [-Wswitch]
    switch (node->type) {
            ^
ldhash.c:419:13: note: add missing switch cases
    switch (node->type) {
            ^
```