### PR TITLE
Fix warning: initializing 'char *const' with an expression of type 'u…

### DIFF
--- a/base64.c
+++ b/base64.c
@@ -62,11 +62,11 @@ static const unsigned char base64_table[65] =
  * not included in out_len.
  */
  /* new lines are disabled */
-unsigned char * LDi_base64_encode(const unsigned char *src, size_t len,
+char * LDi_base64_encode(const char *const src, size_t len,
 			      size_t *out_len)
 {
-	unsigned char *out, *pos;
-	const unsigned char *end, *in;
+	char *out, *pos;
+	const char *end, *in;
 	size_t olen;
 	int line_len;
 

--- a/ldinternal.h
+++ b/ldinternal.h
@@ -68,7 +68,7 @@ struct FeatureRequestEvent {
     LDNode Default;
 };
 
-unsigned char * LDi_base64_encode(const unsigned char *src, size_t len,
+char * LDi_base64_encode(const char *const, size_t len,
 	size_t *out_len);
 void LDi_freehash(LDNode *hash);
 void LDi_freenode(LDNode *node);


### PR DESCRIPTION
…nsigned char *' converts between pointers to integer types with different sign

      [-Wpointer-sign]

```ldnet.c:209:49: warning: passing 'const char *const' to parameter of type 'const unsigned char *' converts between pointers to integer types with different
      sign [-Wpointer-sign]
        char *const b64text = LDi_base64_encode(userjson, strlen(userjson), &b64len);
                                                ^~~~~~~~
./ldinternal.h:71:56: note: passing argument to parameter 'src' here
unsigned char * LDi_base64_encode(const unsigned char *src, size_t len,
                                                       ^
ldnet.c:209:21: warning: initializing 'char *const' with an expression of type 'unsigned char *' converts between pointers to integer types with different sign
      [-Wpointer-sign]
        char *const b64text = LDi_base64_encode(userjson, strlen(userjson), &b64len);
                    ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ldnet.c:312:49: warning: passing 'const char *const' to parameter of type 'const unsigned char *' converts between pointers to integer types with different
      sign [-Wpointer-sign]
        char *const b64text = LDi_base64_encode(userjson, strlen(userjson), &b64len);
                                                ^~~~~~~~
./ldinternal.h:71:56: note: passing argument to parameter 'src' here
unsigned char * LDi_base64_encode(const unsigned char *src, size_t len,
                                                       ^
ldnet.c:312:21: warning: initializing 'char *const' with an expression of type 'unsigned char *' converts between pointers to integer types with different sign
      [-Wpointer-sign]
        char *const b64text = LDi_base64_encode(userjson, strlen(userjson), &b64len);```